### PR TITLE
Set up basic Jupyter Book

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: '3.x'
         cache: 'pip'
     - run: pip install -U jupyter-book
-    - run: make build-book PRE_BUILD_DIR=${{ env.PRE_BUILD_DIR }}
+    - run: jupyter-book build -W -n --keep-going ${{ env.PRE_BUILD_DIR }}
     - run: touch ${{ env.PRE_BUILD_DIR }}/_build/html/.nojekyll
     - uses: JamesIves/github-pages-deploy-action@v4
       with:

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -1,0 +1,31 @@
+name: deploy-book
+
+on:
+  push:
+    branches:
+    - main
+  workflow_dispatch:
+
+env:
+  PRE_BUILD_DIR: "_pre_build"
+
+jobs:
+  deploy-book:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.x'
+        cache: 'pip'
+    - run: pip install -U jupyter-book
+    - run: make build-book PRE_BUILD_DIR=${{ env.PRE_BUILD_DIR }}
+    - run: touch ${{ env.PRE_BUILD_DIR }}/_build/html/.nojekyll
+    - uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: "${{ env.PRE_BUILD_DIR }}/_build/html"
+        # See: https://github.com/marketplace/actions/deploy-pr-preview#ensure-your-main-deployment-is-compatible
+        clean-exclude: pr-preview/
+        force: false

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ env/
 .ipynb_checkpoints/
 */data/
 .gitattributes
+_build/

--- a/README.md
+++ b/README.md
@@ -1,20 +1,17 @@
-<h3 align="center">
-<img src="./docs/images/Logo_Destination_Earth_Colours.png" width=60%>
-</br>
+<img src="./docs/images/Logo_Destination_Earth_Colours.png" width=60% >
 
-</h3>
-
-- [Polytope Examples for DT Data Access](#polytope-examples-for-dt-data-access)
-  - [Access using your Destination Earth Service Platform credentials](#access-using-your-destination-earth-service-platform-credentials)
-  - [Installation](#installation)
-  - [Climate-DT Examples](#climate-dt-examples)
-  - [Extremes-DT Examples](#extremes-dt-examples)
-  - [On-Demand Extremes-DT Examples](#on-demand-extremes-dt-examples)
-  - [NextGEMS Examples](#nextgems-examples)
-  - [Polytope Quota Limits for DestinE](#polytope-quota-limits-for-destine)
-
+<br /><br />
 
 # Polytope Examples for DT Data Access
+
+- [Access using your Destination Earth Service Platform credentials](#access-using-your-destination-earth-service-platform-credentials)
+- [Installation](#installation)
+- [Climate-DT Examples](#climate-dt-examples)
+- [Extremes-DT Examples](#extremes-dt-examples)
+- [On-Demand Extremes-DT Examples](#on-demand-extremes-dt-examples)
+- [NextGEMS Examples](#nextgems-examples)
+- [Polytope Quota Limits for DestinE](#polytope-quota-limits-for-destine)
+
 
 ## Access using your Destination Earth Service Platform credentials
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,26 @@
+title : Polytope Examples for DT Data Access
+author: Adam Warde, James Hawkes, and Tiago Quintino
+logo: 'docs/images/Logo_Destination_Earth_Colours.png'
+
+# Short description about the book
+description: >-
+  Guides to accessing Destination Earth DT data via the Polytope web service hosted on the LUMI Databridge.
+
+execute:
+  execute_notebooks           : off
+
+# HTML-specific settings
+html:
+  home_page_in_navbar         : true
+
+# Interact link settings
+notebook_interface            : "notebook"
+
+# Launch button settings
+repository:
+  url                         : https://github.com/destination-earth-digital-twins/polytope-examples
+  path_to_book                : ""
+
+binder:
+  binderhub_url               : "https://code.insula.destine.eu"
+  text                        : "Launch DestinE Insula (requires login)"

--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,13 @@ html:
 # Interact link settings
 notebook_interface            : "notebook"
 
+# MyST parser settings
+parse:
+  myst_enable_extensions:
+    # don't forget to list any other extensions you want enabled,
+    # including those that are enabled by default! See here: https://jupyterbook.org/en/stable/customize/config.html
+    - html_image
+
 # Launch button settings
 repository:
   url                         : https://github.com/destination-earth-digital-twins/polytope-examples

--- a/_toc.yml
+++ b/_toc.yml
@@ -1,0 +1,15 @@
+format: jb-article
+root: README.md
+sections:
+- file: climate-dt/README.md
+  sections:
+  - glob: climate-dt/*
+- file: extremes-dt/README.md
+  sections:
+  - glob: extremes-dt/*
+- file: on-demand-extremes-dt/README.md
+  sections:
+  - glob: on-demand-extremes-dt/*
+- file: nextgems/README.md
+  sections:
+  - glob: nextgems/*

--- a/climate-dt/README.md
+++ b/climate-dt/README.md
@@ -1,0 +1,1 @@
+# Climate DT

--- a/extremes-dt/README.md
+++ b/extremes-dt/README.md
@@ -1,0 +1,1 @@
+# Extremes DT

--- a/on-demand-extremes-dt/README.md
+++ b/on-demand-extremes-dt/README.md
@@ -1,0 +1,1 @@
+# On-Demand Extremes-DT


### PR DESCRIPTION
## What I'm changing

Added simple setup of [Jupyter Book](https://jupyterbook.org/en/stable/start/example-book.html) with minimal changes to existing repo contents.

I chose Jupyter Book, because another ECMWF project is already using it: https://github.com/ecmwf-projects/c3s2-eqc-quality-assessment

Addresses
- #38 

## How I did it

- Added a `README.md` to each folder to function as a section heading in the table of contents
- Added `_config.yml` and `_toc.yml` required by Jupyter Book
- Copied the GitHub Action from https://github.com/ecmwf-projects/c3s2-eqc-quality-assessment/blob/main/.github/workflows/deploy-book.yml

## How to test it

1. `pip install -U jupyter-book`
2. `jupyter-book build .`
3.  open `_build` folder in your browser, as instructed by the build script

    <img width="1472" height="1352" alt="image" src="https://github.com/user-attachments/assets/6bfb8643-6cad-45de-97e6-58609c469107" />

4. Observe the following things working:
   - Table of contents has a section for each folder, listing all `.ipynb` notebooks in that folder
   - Links from root README to notebooks resolve to the respective page in the rendered docs
 5. Observe the following things NOT working:
    - Header image in root README
    - Listing `.py` files

If you're happy with this, please someone from ECMWF expedite the GitHub pages deployment. Probably needs some approvals or credentials or so.