### PR TITLE
Add Sphinx configuration for sitemap generation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,3 +31,11 @@ repository:
 binder:
   binderhub_url               : "https://code.insula.destine.eu"
   text                        : "Launch DestinE Insula (requires login)"
+
+# Sitemap
+sphinx:
+  config:
+    html_baseurl            : "https://destination-earth-digital-twins.github.io/polytope-examples/"
+    sitemap_url_scheme      : "{link}"
+  extra_extensions:
+    - sphinx_sitemap


### PR DESCRIPTION
## What I am changing

Adds Sphinx config for generating a sitemap

Closes #60 

## How I did it

Followed instructions in https://github.com/jupyter-book/jupyter-book/issues/880#issuecomment-1600560392

I have not been able to verify that it works, because of this error:

```
$ pip install -r requirements.txt
$ pip install -r book-requirements.txt
$ make build-book
rm -fr _pre_build
cp -r * /var/folders/fj/h7p8zmrs5pv538jqx4b0z7c80000gn/T/tmp.q79PorV7Ts
rm -fr /var/folders/fj/h7p8zmrs5pv538jqx4b0z7c80000gn/T/tmp.q79PorV7Ts/__MACOSX
mv /var/folders/fj/h7p8zmrs5pv538jqx4b0z7c80000gn/T/tmp.q79PorV7Ts _pre_build
python scripts/pre-build.py _pre_build "--no-disclaimer"
jupyter-book build -n --keep-going _pre_build
error: unknown option '-n'
make: *** [build-book] Error 1
```

## How you can test it

Run the build locally, see that the sitemap gets added.