### PR TITLE
Add fix needed for compatibility with earthkit-data >= 1.0

### DIFF
--- a/climate-dt/explorer/polytope_zarr.py
+++ b/climate-dt/explorer/polytope_zarr.py
@@ -648,7 +648,12 @@ class PolytopeZarrStore(MutableMapping):
         for s in chunk_shape:
             n_cells *= s
 
-        fields = list(data)
+        # earthkit-data >= 1.0 returns a GribData wrapper that is not directly
+        # iterable; call to_fieldlist() to get a concrete iterable FieldList.
+        try:
+            fields = list(data.to_fieldlist())
+        except AttributeError:
+            fields = list(data)
 
         # ── Time dimension: match fields by metadata ────────────────────
         if self._batch_dim == "time" and dims[batch_pos] == "time":


### PR DESCRIPTION
This fix allows to run https://github.com/destination-earth-digital-twins/polytope-examples/blob/main/climate-dt/explorer/03_lazy_browse_portfolio.ipynb, while otherwise it fails with the following error when using earthkit-data>= 1.0:
```
Fetching {'cell': 196608} values...
  ⚡ batching 12 time chunks for avg_2t
⚠ fetch avg_2t chunk 0.245.0: 'GribData' object is not iterable
```